### PR TITLE
fix: refactor code to calculate weekNumber

### DIFF
--- a/code/scripts/Menu.js
+++ b/code/scripts/Menu.js
@@ -5,18 +5,15 @@ class UpdateMenu {
     // Polyfill for Date.prototype.getWeek()
     Date.prototype.getWeek = function () {
       var date = new Date(this.getTime());
-      date.setHours(0, 0, 0, 0);
-      date.setDate(date.getDate() + 3 - ((date.getDay() + 6) % 7));
-      var week1 = new Date(date.getFullYear(), 0, 4);
-      return (
-        1 +
-        Math.round(
-          ((date.getTime() - week1.getTime()) / 86400000 -
-            3 +
-            ((week1.getDay() + 6) % 7)) /
-            7
-        )
-      );
+      const firstDayOfMonth = new Date(date.getFullYear(), date.getMonth(), 1);
+      const firstDayOfWeek = firstDayOfMonth.getDay();
+
+      const dayOfMonth = date.getDate();
+      const adjustedDay = dayOfMonth + firstDayOfWeek - 1;
+
+      let weekNumber = Math.floor(adjustedDay / 7) % 4;
+
+      return weekNumber;
     };
 
     let today = new Date();


### PR DESCRIPTION
Fixes #3 

I have refactored the code in Menu.js.

New logic:
1. Calculate day on first date of the month.
2. Calculate the difference between the current date and the start date of month.
3. Calculated week number by dividing the above difference by 7.

Expected Outcome:
The refactored logic should give the correct week number of the month.